### PR TITLE
fix #8 swipeout border issue.

### DIFF
--- a/src/components/SwipeOut.vue
+++ b/src/components/SwipeOut.vue
@@ -134,7 +134,8 @@
 			_distanceSwiped() {
 				const contentRect = this.$refs.content.getBoundingClientRect();
 				const elementRect = this.$el.getBoundingClientRect();
-				return contentRect.left - elementRect.left;
+				const borderLeft = getComputedStyle(this.$el, null).getPropertyValue("border-left-width");
+				return contentRect.left - elementRect.left - parseFloat(borderLeft);
 			},
 			_startListener(event) {
 				if (this.disabled)


### PR DESCRIPTION
Hello @nanov ,

Would you please review and merge this pull request. When the  `.swipeout` element has some border the swipe no longer works.

I managed to fix it and tested on both chrome and safari browsers.

You can reproduce this issue by change code in `App.vue`  from

```css
.swipeout-list-item {
	flex: 1;
	border-bottom: 1px solid lightgray;
	&:last-of-type {
		border-bottom: none;
	}
}
```

TO 

```css
.swipeout-list-item {
	flex: 1;
	border: 1px solid lightgray;
	&:last-of-type {
		border: none;
	}
}
```